### PR TITLE
Fixed GUI bug where scale max & min not updating

### DIFF
--- a/Assets/Scripts/Menu/HistogramMenuController.cs
+++ b/Assets/Scripts/Menu/HistogramMenuController.cs
@@ -33,7 +33,7 @@ public class HistogramMenuController : MonoBehaviour
 
             if (getFirstActiveDataSet() != null)
             {
-                VolumeDataSet dataSet = getFirstActiveDataSet().GetDatsSet();
+                VolumeDataSet dataSet = getFirstActiveDataSet().GetDataSet();
              
                 minText.text = histogramHelper.CurrentMin.ToString();  
                 maxText.text = histogramHelper.CurrentMax.ToString();
@@ -45,22 +45,22 @@ public class HistogramMenuController : MonoBehaviour
     {
         if (DecreaseMinScaleButton.gameObject.GetComponent<UI.UserSelectableItem>().isPressed)
         {
-           minText.text = Mathf.Clamp(float.Parse(minText.text) - 0.01f, getFirstActiveDataSet().GetDatsSet().MinValue* 2, float.Parse(maxText.text)).ToString(); 
+           minText.text = Mathf.Clamp(float.Parse(minText.text) - 0.01f, getFirstActiveDataSet().GetDataSet().MinValue* 2, float.Parse(maxText.text)).ToString(); 
         }
 
         if (DecreaseMaxScaleButton.gameObject.GetComponent<UI.UserSelectableItem>().isPressed)
         {
-            maxText.text = Mathf.Clamp(float.Parse(maxText.text) - 0.01f, float.Parse(minText.text), getFirstActiveDataSet().GetDatsSet().MaxValue* 2).ToString();
+            maxText.text = Mathf.Clamp(float.Parse(maxText.text) - 0.01f, float.Parse(minText.text), getFirstActiveDataSet().GetDataSet().MaxValue* 2).ToString();
         }
 
         if (IncreaseMinScaleButton.gameObject.GetComponent<UI.UserSelectableItem>().isPressed)
         {
-            minText.text = Mathf.Clamp(float.Parse(minText.text) + 0.01f, getFirstActiveDataSet().GetDatsSet().MinValue * 2, float.Parse(maxText.text)).ToString();
+            minText.text = Mathf.Clamp(float.Parse(minText.text) + 0.01f, getFirstActiveDataSet().GetDataSet().MinValue * 2, float.Parse(maxText.text)).ToString();
         }
 
         if (IncreaseMaxScaleButton.gameObject.GetComponent<UI.UserSelectableItem>().isPressed)
         {
-            maxText.text = Mathf.Clamp(float.Parse(maxText.text) + 0.01f, float.Parse(minText.text), getFirstActiveDataSet().GetDatsSet().MaxValue * 2).ToString();
+            maxText.text = Mathf.Clamp(float.Parse(maxText.text) + 0.01f, float.Parse(minText.text), getFirstActiveDataSet().GetDataSet().MaxValue * 2).ToString();
         }
 
     }
@@ -77,14 +77,14 @@ public class HistogramMenuController : MonoBehaviour
 
     public void UpdateButtonHandler()
     {
-      VolumeDataSet.UpdateHistogram(getFirstActiveDataSet().GetDatsSet(), float.Parse(minText.text), float.Parse(maxText.text));
-      histogramHelper.CreateHistogramImg(getFirstActiveDataSet().GetDatsSet().Histogram, getFirstActiveDataSet().GetDatsSet().HistogramBinWidth, float.Parse(minText.text), float.Parse(maxText.text), getFirstActiveDataSet().GetDatsSet().MeanValue, getFirstActiveDataSet().GetDatsSet().StanDev);
+      VolumeDataSet.UpdateHistogram(getFirstActiveDataSet().GetDataSet(), float.Parse(minText.text), float.Parse(maxText.text));
+      histogramHelper.CreateHistogramImg(getFirstActiveDataSet().GetDataSet().Histogram, getFirstActiveDataSet().GetDataSet().HistogramBinWidth, float.Parse(minText.text), float.Parse(maxText.text), getFirstActiveDataSet().GetDataSet().MeanValue, getFirstActiveDataSet().GetDataSet().StanDev);
     }
 
     public void ResetButtonHandler()
     {
-        VolumeDataSet.UpdateHistogram(getFirstActiveDataSet().GetDatsSet(), getFirstActiveDataSet().GetDatsSet().MinValue, getFirstActiveDataSet().GetDatsSet().MaxValue);
-        histogramHelper.CreateHistogramImg(getFirstActiveDataSet().GetDatsSet().Histogram, getFirstActiveDataSet().GetDatsSet().HistogramBinWidth, getFirstActiveDataSet().GetDatsSet().MinValue, getFirstActiveDataSet().GetDatsSet().MaxValue, getFirstActiveDataSet().GetDatsSet().MeanValue, getFirstActiveDataSet().GetDatsSet().StanDev);
+        VolumeDataSet.UpdateHistogram(getFirstActiveDataSet().GetDataSet(), getFirstActiveDataSet().GetDataSet().MinValue, getFirstActiveDataSet().GetDataSet().MaxValue);
+        histogramHelper.CreateHistogramImg(getFirstActiveDataSet().GetDataSet().Histogram, getFirstActiveDataSet().GetDataSet().HistogramBinWidth, getFirstActiveDataSet().GetDataSet().MinValue, getFirstActiveDataSet().GetDataSet().MaxValue, getFirstActiveDataSet().GetDataSet().MeanValue, getFirstActiveDataSet().GetDataSet().StanDev);
     }
 
     public void UpdateUI(float min, float max, Sprite img)

--- a/Assets/Scripts/UI/CanvassDesktop.cs
+++ b/Assets/Scripts/UI/CanvassDesktop.cs
@@ -608,7 +608,7 @@ public class CanvassDesktop : MonoBehaviour
 
     private void populateStatsValue()
     {
-        VolumeDataSet volumeDataSet = getFirstActiveDataSet().GetDatsSet();
+        VolumeDataSet volumeDataSet = getFirstActiveDataSet().GetDataSet();
 
         Transform stats = statsPanelContent.gameObject.transform.Find("Stats_container").gameObject.transform.Find("Viewport").gameObject.transform.Find("Content").gameObject.transform.Find("Stats");
         stats.gameObject.transform.Find("Line_min").gameObject.transform.Find("InputField_min").GetComponent<TMP_InputField>().text = volumeDataSet.MinValue.ToString();
@@ -644,7 +644,7 @@ public class CanvassDesktop : MonoBehaviour
             .gameObject.transform.Find("InputField_min").GetComponent<TMP_InputField>().text);
         float histMax = float.Parse(statsPanelContent.gameObject.transform.Find("Stats_container").gameObject.transform.Find("Viewport").gameObject.transform.Find("Content").gameObject.transform.Find("Stats").gameObject.transform.Find("Line_max")
             .gameObject.transform.Find("InputField_max").GetComponent<TMP_InputField>().text);
-        VolumeDataSet volumeDataSet = getFirstActiveDataSet().GetDatsSet();
+        VolumeDataSet volumeDataSet = getFirstActiveDataSet().GetDataSet();
         histogramHelper.CreateHistogramImg(volumeDataSet.Histogram, volumeDataSet.HistogramBinWidth, histMin, histMax, volumeDataSet.MeanValue, volumeDataSet.StanDev, sigma);
     }
 
@@ -653,14 +653,14 @@ public class CanvassDesktop : MonoBehaviour
         statsPanelContent.gameObject.transform.Find("Stats_container").gameObject.transform.Find("Viewport").gameObject.transform.Find("Content").gameObject.transform.Find("Stats")
             .gameObject.transform.Find("Line_sigma").gameObject.transform.Find("Dropdown").GetComponent<TMP_Dropdown>().value = 0;
 
-        VolumeDataSet.UpdateHistogram(getFirstActiveDataSet().GetDatsSet(), getFirstActiveDataSet().GetDatsSet().MinValue, getFirstActiveDataSet().GetDatsSet().MaxValue);
+        VolumeDataSet.UpdateHistogram(getFirstActiveDataSet().GetDataSet(), getFirstActiveDataSet().GetDataSet().MinValue, getFirstActiveDataSet().GetDataSet().MaxValue);
         populateStatsValue();
     }
     
     public void UpdateScaleMin(String min)
     {
         VolumeDataSetRenderer volumeDataSetRenderer = getFirstActiveDataSet();
-        VolumeDataSet volumeDataSet = volumeDataSetRenderer.GetDatsSet();
+        VolumeDataSet volumeDataSet = volumeDataSetRenderer.GetDataSet();
         float newMin = float.Parse(min);
         float histMin = newMin;
         float histMax = float.Parse(statsPanelContent.gameObject.transform.Find("Stats_container").gameObject.transform.Find("Viewport").gameObject.transform.Find("Content").gameObject.transform.Find("Stats").gameObject.transform.Find("Line_max")
@@ -675,7 +675,7 @@ public class CanvassDesktop : MonoBehaviour
     public void UpdateScaleMax(String max)
     {
         VolumeDataSetRenderer volumeDataSetRenderer = getFirstActiveDataSet();
-        VolumeDataSet volumeDataSet = volumeDataSetRenderer.GetDatsSet();
+        VolumeDataSet volumeDataSet = volumeDataSetRenderer.GetDataSet();
         float newMax = float.Parse(max);
         float histMin = float.Parse(statsPanelContent.gameObject.transform.Find("Stats_container").gameObject.transform.Find("Viewport").gameObject.transform.Find("Content").gameObject.transform.Find("Stats").gameObject.transform.Find("Line_min")
             .gameObject.transform.Find("InputField_min").GetComponent<TMP_InputField>().text);

--- a/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
@@ -296,7 +296,7 @@ namespace VolumeData
 
         }
 
-        public VolumeDataSet GetDatsSet()
+        public VolumeDataSet GetDataSet()
         {
             return _dataSet;
         }


### PR DESCRIPTION
When adjusting Scale Min and Scale Max under Stats, the VolumeDataSetRenderer was not updating with the new values.