### PR TITLE
Added tunnel vignette toggle to config file

### DIFF
--- a/Assets/Scripts/VolumeData/Config.cs
+++ b/Assets/Scripts/VolumeData/Config.cs
@@ -33,7 +33,9 @@ namespace VolumeData
         [JsonConverter(typeof(StringEnumConverter))]
         public ConfidenceLevel voiceCommandConfidenceLevel = ConfidenceLevel.Low;
 
-        public bool tunnellingVignette = true;
+        public bool tunnellingVignetteOn = true;
+        public float tunnellingVignetteIntensity = 1.0f;
+        public float tunnellingVignetteEnd = 0.40f;
         
         public class RenderConfig
         {

--- a/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
@@ -282,6 +282,7 @@ namespace VolumeData
             MaximumCubeSizeInMB = config.gpuMemoryLimitMb;
             ColorMap = config.defaultColorMap;
             ScalingType = config.defaultScalingType;
+            VignetteFadeEnd = config.tunnellingVignetteEnd;
             
             if (RandomVolume)
                 _dataSet = VolumeDataSet.LoadRandomFitsCube(0, RandomCubeSize, RandomCubeSize, RandomCubeSize, RandomCubeSize);

--- a/Assets/Scripts/VolumeData/VolumeInputController.cs
+++ b/Assets/Scripts/VolumeData/VolumeInputController.cs
@@ -101,7 +101,6 @@ public class VolumeInputController : MonoBehaviour
     private float _previousControllerHeight;
     private LocomotionState _locomotionState;
     
-    private bool tunnelVignetteVisible = true;
     
     // Interactions
     public StateMachine<InteractionState, InteractionEvents> InteractionStateMachine { get; private set; }
@@ -127,8 +126,10 @@ public class VolumeInputController : MonoBehaviour
     public bool scrollDown = false;
 
     // Vignetting
+    private bool _tunnellingVignetteOn = true;
     private float _currentVignetteIntensity = 0;
     private float _targetVignetteIntensity = 0;
+    private float _maxVignetteIntensity = 1.0f;
 
     // Selecting
     private readonly Stopwatch _selectionStopwatch = new Stopwatch();
@@ -164,7 +165,8 @@ public class VolumeInputController : MonoBehaviour
     private void OnEnable()
     {
         var config = Config.Instance;
-        tunnelVignetteVisible = config.tunnellingVignette;
+        _tunnellingVignetteOn = config.tunnellingVignetteOn;
+        _maxVignetteIntensity = config.tunnellingVignetteIntensity;
         _vrFamily = DetermineVRFamily();
         Vector3 pointerOffset = PointerOffsetsLeft[_vrFamily];
         if (_player == null)
@@ -512,7 +514,7 @@ public class VolumeInputController : MonoBehaviour
     private void StateTransitionIdleToMoving()
     {
         _locomotionState = LocomotionState.Moving;
-        _targetVignetteIntensity = 1;
+        _targetVignetteIntensity = _maxVignetteIntensity;
     }
     
     public void StartThresholdEditing(bool editingMax)
@@ -652,7 +654,7 @@ public class VolumeInputController : MonoBehaviour
     private void Update()
     {
         // Common update functions
-        if (tunnelVignetteVisible)
+        if (_tunnellingVignetteOn)
             UpdateVignette();
         if (Camera.current)
         {


### PR DESCRIPTION
The tunnelling vignette darkens the edges of the user's VR view when navigating with the controllers in order to minimize simulation sickness. This PR adds an option to the config file whether to display this vignette or not. 

closes #299 