### PR TITLE
Fixed the bug of new painted sources not being added to the menu list

### DIFF
--- a/Assets/Scripts/FeatureData/FeatureSetManager.cs
+++ b/Assets/Scripts/FeatureData/FeatureSetManager.cs
@@ -140,7 +140,7 @@ namespace DataFeatures
             featureSetRenderer.transform.localScale = new Vector3(1 / CubeDimensions.x, 1 / CubeDimensions.y, 1 / CubeDimensions.z);
             // Shift by half a voxel (because voxel center has integer coordinates, not corner)
             featureSetRenderer.transform.localPosition -= featureSetRenderer.transform.localScale * 0.5f;
-            GeneratedFeatureSetList.Add(featureSetRenderer); //TODO: change to GeneratedFeatureSetList later
+            GeneratedFeatureSetList.Add(featureSetRenderer);
             return featureSetRenderer; 
         }
         // Creates new empty FeatureSetRenderer for adding Features

--- a/Assets/Scripts/VolumeData/VolumeDataSet.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataSet.cs
@@ -458,6 +458,8 @@ namespace VolumeData
                     var rawStrings = new [] {$"{sourceStats.sum}", $"{sourceStats.peak}", $"{sourceStats.channelVsys}", $"{sourceStats.channelW20}", $"{sourceStats.veloVsys}", $"{sourceStats.veloW20}"};
                     var feature = new Feature(boxMin, boxMax, _maskFeatureSet.FeatureColor, name, _maskFeatureSet.FeatureList.Count, maskVal - 1, rawStrings, _maskFeatureSet, _maskFeatureSet.FeatureList[0].Visible);
                     _maskFeatureSet.AddFeature(feature);
+                    _maskFeatureSet.FeatureMenuScrollerDataSource.InitData();       // Reinitialize the data source to include the new feature
+                    _maskFeatureSet.FeatureManager.NeedToRespawnMenuList = true;
                 }
             }
         }


### PR DESCRIPTION
Previously painting new sources would not be added to the menu list of features. This required the user to save the new mask and reload the mask to populate the list. This has been fixed.

Closes #294 