### PR TITLE
Added scroll buttons back to source menu

### DIFF
--- a/Assets/Prefabs/FeatureSet/Recyclable Scroll View Variant.prefab
+++ b/Assets/Prefabs/FeatureSet/Recyclable Scroll View Variant.prefab
@@ -124,7 +124,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 881031908}
         m_TargetAssemblyTypeName: CustomDragHandler, Assembly-CSharp
-        m_MethodName: MoveUp
+        m_MethodName: MoveUpClick
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -273,7 +273,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 881031908}
         m_TargetAssemblyTypeName: CustomDragHandler, Assembly-CSharp
-        m_MethodName: MoveDown
+        m_MethodName: MoveDownClick
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -469,6 +469,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   anchorPoint: {fileID: 8814787936857429663}
   scrollSpeed: 20
+  buttonClickMovement: 110
 --- !u!114 &881031910
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/UI/CustomDragHandler.cs
+++ b/Assets/Scripts/UI/CustomDragHandler.cs
@@ -13,6 +13,7 @@ public class CustomDragHandler : MonoBehaviour
                                         // Set this to Content object when using ScrollRect to allow clamps to work properly.
                                         // This requires adjusting the Content size if spawning objects at runtime.
     public int scrollSpeed;
+    public int buttonClickMovement;
     private RectTransform anchorPointPosition;
     public float Spawn_initial_y {get; private set;}
 
@@ -28,9 +29,19 @@ public class CustomDragHandler : MonoBehaviour
     {
         anchorPointPosition.localPosition += Vector3.down * scrollSpeed;
     }
-
+    
     public void MoveDown()
     {
         anchorPointPosition.localPosition += Vector3.up * scrollSpeed;
+    }
+    
+    public void MoveUpClick()
+    {
+        anchorPointPosition.localPosition += Vector3.down * buttonClickMovement;
+    }
+
+    public void MoveDownClick()
+    {
+        anchorPointPosition.localPosition += Vector3.up * buttonClickMovement;
     }
 }


### PR DESCRIPTION
When the recyclable scroll functionality of the source menu was implemented, the scroll (up/down) buttons were removed. This puts them back in.

Closes #218 