### PR TITLE
Add error message popups for mask commands with no mask loaded.

### DIFF
--- a/Assets/Scripts/Menu/QuickMenuController.cs
+++ b/Assets/Scripts/Menu/QuickMenuController.cs
@@ -72,6 +72,14 @@ public class QuickMenuController : MonoBehaviour
         return null;
     }
 
+    /// <summary>
+    /// Function that gets called if a function related to the mask is called without a mask that is loaded.
+    /// </summary>
+    private void throwMissingMaskError()
+    {
+        ToastNotification.ShowError("No mask loaded for this functionality!");
+    }
+
     public void Exit()
     {
         if (_activeDataSet.FileChanged)
@@ -164,6 +172,12 @@ public class QuickMenuController : MonoBehaviour
 
     public void ToggleMask()
     {
+        if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+        {
+            throwMissingMaskError();
+            return;
+        }
+
         if (maskstatus == 3)
             maskstatus = -1;
         maskstatus++;
@@ -200,6 +214,12 @@ public class QuickMenuController : MonoBehaviour
 
     private void setMask(MaskMode mode)
     {
+        if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+        {
+            throwMissingMaskError();
+            return;
+        }
+
         if (_activeDataSet)
         {
             _activeDataSet.MaskMode = mode;
@@ -259,6 +279,12 @@ public class QuickMenuController : MonoBehaviour
 
     public void SaveMask()
     {
+        if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+        {
+            throwMissingMaskError();
+            return;
+        }
+
         if (exportPopup.activeSelf)
             exportPopup.SetActive(false);
         
@@ -320,6 +346,12 @@ public class QuickMenuController : MonoBehaviour
 
     public void SaveOverwriteMask()
     {
+        if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+        {
+            throwMissingMaskError();
+            return;
+        }
+
         _activeDataSet.SaveMask(true);
         _volumeInputController.VibrateController(_volumeInputController.PrimaryHand);
         SaveCancel();
@@ -327,6 +359,12 @@ public class QuickMenuController : MonoBehaviour
 
     public void SaveNewMask()
     {
+        if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+        {
+            throwMissingMaskError();
+            return;
+        }
+        
         _activeDataSet.SaveMask(false);
         _volumeInputController.VibrateController(_volumeInputController.PrimaryHand);
         SaveCancel();

--- a/Assets/Scripts/VolumeData/VolumeCommandController.cs
+++ b/Assets/Scripts/VolumeData/VolumeCommandController.cs
@@ -110,6 +110,14 @@ namespace VolumeData
             ExecuteVoiceCommand(args.text);
         }
 
+        /// <summary>
+        /// Function that gets called if a function related to the mask is called without a mask that is loaded.
+        /// </summary>
+        private void throwMissingMaskError()
+        {
+            ToastNotification.ShowError("No mask loaded for this functionality!");
+        }
+
         private void ExecuteVoiceCommand(string args)
         { 
             if (args == Keywords.EditThresholdMin)
@@ -431,6 +439,12 @@ namespace VolumeData
 
         public void setMask(MaskMode mode)
         {
+            if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+            {
+                throwMissingMaskError();
+                return;
+            }
+            
             if (_activeDataSet)
             {
                 _activeDataSet.MaskMode = mode;
@@ -481,6 +495,12 @@ namespace VolumeData
 
         public void ShowMaskOutline()
         {
+            if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+            {
+                throwMissingMaskError();
+                return;
+            }
+
             foreach (var dataSet in _dataSets)
             {
                 dataSet.DisplayMask = true;
@@ -489,6 +509,12 @@ namespace VolumeData
 
         public void HideMaskOutline()
         {
+            if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+            {
+                throwMissingMaskError();
+                return;
+            }
+
             foreach (var dataSet in _dataSets)
             {
                 dataSet.DisplayMask = false;
@@ -518,6 +544,12 @@ namespace VolumeData
 
         public void SetMaskValue()
         {
+            if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+            {
+                throwMissingMaskError();
+                return;
+            }
+
             _volumeInputController.InteractionStateMachine.Fire(VolumeInputController.InteractionEvents.StartEditSource);
         }
 


### PR DESCRIPTION
  * Closes #332.
  * Should be extensible to any error (e.g., voice command not recognised).