### PR TITLE
Fix mask interaction error messages when cube is downsampled

### DIFF
--- a/Assets/Scripts/Menu/QuickMenuController.cs
+++ b/Assets/Scripts/Menu/QuickMenuController.cs
@@ -214,7 +214,7 @@ public class QuickMenuController : MonoBehaviour
 
     private void setMask(MaskMode mode)
     {
-        if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+        if (_activeDataSet.Mask == null)
         {
             throwMissingMaskError();
             return;
@@ -279,7 +279,7 @@ public class QuickMenuController : MonoBehaviour
 
     public void SaveMask()
     {
-        if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+        if (_activeDataSet.Mask == null)
         {
             throwMissingMaskError();
             return;
@@ -346,7 +346,7 @@ public class QuickMenuController : MonoBehaviour
 
     public void SaveOverwriteMask()
     {
-        if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+        if (_activeDataSet.Mask == null)
         {
             throwMissingMaskError();
             return;
@@ -359,7 +359,7 @@ public class QuickMenuController : MonoBehaviour
 
     public void SaveNewMask()
     {
-        if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+        if (_activeDataSet.Mask == null)
         {
             throwMissingMaskError();
             return;

--- a/Assets/Scripts/VolumeData/VolumeCommandController.cs
+++ b/Assets/Scripts/VolumeData/VolumeCommandController.cs
@@ -439,7 +439,7 @@ namespace VolumeData
 
         public void setMask(MaskMode mode)
         {
-            if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+            if (_activeDataSet.Mask == null)
             {
                 throwMissingMaskError();
                 return;
@@ -495,7 +495,7 @@ namespace VolumeData
 
         public void ShowMaskOutline()
         {
-            if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+            if (_activeDataSet.Mask == null)
             {
                 throwMissingMaskError();
                 return;
@@ -509,7 +509,7 @@ namespace VolumeData
 
         public void HideMaskOutline()
         {
-            if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+            if (_activeDataSet.Mask == null)
             {
                 throwMissingMaskError();
                 return;
@@ -544,7 +544,7 @@ namespace VolumeData
 
         public void SetMaskValue()
         {
-            if (_activeDataSet.Mask == null || _activeDataSet.Mask.RegionCube == null)
+            if (_activeDataSet.Mask == null)
             {
                 throwMissingMaskError();
                 return;


### PR DESCRIPTION
Fixes error described by Tom when cube is downsampled and mask interactions are attempted. Resolves #345.