### PR TITLE
Fix inconsistent floating point number formatting between systems

### DIFF
--- a/Assets/Scripts/UI/CanvassDesktop.cs
+++ b/Assets/Scripts/UI/CanvassDesktop.cs
@@ -72,6 +72,14 @@ public class CanvassDesktop : MonoBehaviour
     protected Coroutine loadCubeCoroutine;
     protected Coroutine showLoadDialogCoroutine;
 
+
+    private void Awake()
+    {
+        // Change the culture to invariant to avoid issues with parsing floats
+        System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+        System.Threading.Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+    }
+
     // Start is called before the first frame update
     void Start()
     {


### PR DESCRIPTION
This sets the entire game thread culture to invariant, so that decimals are used for formatting floating point numbers.

Closes #124 