### PR TITLE
Disable the editing of anchor corners for mask features

### DIFF
--- a/Assets/Scripts/VolumeData/VolumeInputController.cs
+++ b/Assets/Scripts/VolumeData/VolumeInputController.cs
@@ -945,7 +945,8 @@ public class VolumeInputController : MonoBehaviour
         {
             dataSet.SetRegionPosition(cursorPosWorldSpace, false);
         }
-        else if (currentState == InteractionState.Editing && HasEditingAnchor)
+        // Edit the region bounds in Editing state, but not for mask feature sets
+        else if (currentState == InteractionState.Editing && HasEditingAnchor && _editingFeature.FeatureSetParent.FeatureSetType != FeatureSetType.Mask)
         {
             var voxelPosition = dataSet.GetVoxelPosition(cursorPosWorldSpace);
             var newCornerMin = _editingFeature.CornerMin;


### PR DESCRIPTION
This adds in an additional check when the user tries to edit the anchor corners of feature boxes. If they belong to a mask-generated feature, than the corner is not editable.

Closes #304 