### PR TITLE
Fix issue with saving subcubes and submasks.

### DIFF
--- a/Assets/Scripts/PluginInterface/FitsReader.cs
+++ b/Assets/Scripts/PluginInterface/FitsReader.cs
@@ -262,9 +262,13 @@ public class FitsReader
     public static extern int FitsCopyFile(IntPtr infptr, IntPtr outfptr, out int status);
 
     [DllImport("idavie_native")]
+    public static extern int FitsCopyImageSection(string inFile, string outFile, string section, string historyTimeStamp, int selectedHDU, out int status);
+
+    [DllImport("idavie_native")]
     public static extern int FitsCopyCubeSection(IntPtr infptr, IntPtr outfptr, string section, out int status);
 
     [DllImport("idavie_native")]
+    [Obsolete("Replaced by FitsWriteSubImageInt16, which is more flexible.")]
     public static extern int FitsWriteImageInt16(IntPtr fptr, int dims, long nelements, IntPtr array, out int status);
 
     [DllImport("idavie_native")]

--- a/Assets/Scripts/VolumeData/VolumeDataSet.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataSet.cs
@@ -1416,67 +1416,82 @@ namespace VolumeData
             return new Vector3Int(x, y, z);
         }
         
-        public int SaveSubCubeFromOriginal(Vector3Int cornerMin, Vector3Int cornerMax, VolumeDataSet maskDataSet)
+        /// <summary>
+        /// Saves a subcube from cornerMin to cornerMax of this data file, as a separate file.
+        /// </summary>
+        /// <param name="cornerMin">The first voxel index to be saved. Should be dataspace indices.</param>
+        /// <param name="cornerMax">The last voxel index to be saved. Should be dataspace indices.</param>
+        /// <param name="cornerMinWorld">The first voxel index to be saved. Should be worldspace indices. Used for mask data extraction.</param>
+        /// <param name="cornerMaxWorld">The last voxel index to be saved. Should be worldspace indices. Used for mask data extraction.</param>
+        /// <param name="maskDataSet">The mask dataset attached to this dataset.</param>
+        /// <returns>0 if successful, a FITS error otherwise.</returns>
+        public int SaveSubCubeFromOriginal(Vector3Int cornerMin, Vector3Int cornerMax, Vector3Int cornerMinWorld, Vector3Int cornerMaxWorld, VolumeDataSet maskDataSet)
         {
-            IntPtr oldFitsPtr = IntPtr.Zero;
-            IntPtr newFitsPtr = IntPtr.Zero;
             int status = 0;
             var directoryPath = Path.GetDirectoryName(FileName);
             var timeStamp = DateTime.Now.ToString("yyyyMMdd_Hmmss");
             var newFilename = $"{Path.GetFileNameWithoutExtension(FileName)}_subCube_{timeStamp}.fits";
             var filePath = Path.Combine(directoryPath, newFilename);
             var maskFilePath = Path.Combine(directoryPath, $"{Path.GetFileNameWithoutExtension(FileName)}_subCube_{timeStamp}_mask.fits");
-            Vector3Int offset = new Vector3Int(this.subsetBounds[0] - 1, this.subsetBounds[2] - 1, this.subsetBounds[4] - 1);
             // Works only with 3D cubes for now... need 4D askap capability
-            Debug.Log("Attempting to load file:" + FileName);
-            if (FitsReader.FitsOpenFile(out oldFitsPtr, FileName, out status, true) == 0)
+            string section = $"{cornerMin.x}:{cornerMax.x},{cornerMin.y}:{cornerMax.y},{cornerMin.z}:{cornerMax.z}";
+            var timeStampNow = DateTime.Now.ToString("MM/dd/yyyy HH:mm:ss");
+            string historyTimeStamp = $"Saved by iDaVIE at {timeStampNow}";
+            Debug.Log("Attempting to copy image section " + section + " from file: " + FileName + " to " + newFilename + ".");
+            if (FitsReader.FitsCopyImageSection(FileName, filePath, section, historyTimeStamp, SelectedHdu, out status) == 0)
             {
-                Debug.Log("Old file opened successfully.");
-                if (FitsReader.FitsCreateFile(out newFitsPtr, filePath, out status) == 0)
+                if (maskDataSet != null)
                 {
-                    Debug.Log("New file created successfully.");
-                    FitsReader.FitsCopyFile(oldFitsPtr, newFitsPtr, out status);
-                    Debug.Log("File copy attempted.");
-                    if (maskDataSet != null)
+                    var newFitsPtr = IntPtr.Zero;
+                    if (FitsReader.FitsOpenFile(out newFitsPtr, filePath, out status, true) == 0)
+                        SaveSubMask(maskFilePath, cornerMinWorld, cornerMaxWorld, newFitsPtr, maskDataSet);
+                    else
                     {
-                        SaveSubMask(maskFilePath, cornerMin, cornerMax, newFitsPtr, maskDataSet);
+                        Debug.LogWarning($"Error opening new subcube fits file (Error #{status.ToString()})!");
                     }
                     FitsReader.FitsCloseFile(newFitsPtr, out status);
                 }
-                FitsReader.FitsCloseFile(oldFitsPtr, out status);
-            }
-            else
-                Debug.LogWarning("Could not open old file!");
-
-            if (status != 0)
-            {
-                ToastNotification.ShowError($"Error saving sub-cube (Error #{status.ToString()})");
-            }
-            else
-            {
-                ToastNotification.ShowSuccess($"Sub-cube saved to ${newFilename}");
+                ToastNotification.ShowSuccess($"Sub-cube saved to {filePath}");
+                Debug.Log($"Successfully copied image section {section} from file: {FileName} to {filePath}.");
                 if (maskDataSet != null)
                 {
-                    ToastNotification.ShowSuccess($"Submask saved to ${Path.GetFileName(maskFilePath)}");
+                    ToastNotification.ShowSuccess($"Submask saved to {Path.GetFileName(maskFilePath)}");
+                    Debug.Log($"Saved submask to {Path.GetFileName(maskFilePath)}");
                 }
+            }
+            else
+            {
+                Debug.LogWarning("Could not copy image section!");
+                ToastNotification.ShowError($"Error saving sub-cube (Error #{status.ToString()})");
             }
 
             return status;
         }
 
-        public int SaveSubMask(string filePath, Vector3Int cornerMin, Vector3Int cornerMax, IntPtr subCubeFitsPtr, VolumeDataSet maskDataSet)
+        /// <summary>
+        /// Saves the submask of the current mask, from cornerMin to cornerMax in the world space.
+        /// This mask data is in the current image data, and is therefore in the world space.
+        /// </summary>
+        /// <param name="filePath">The filepath destination of the new submask file.</param>
+        /// <param name="cornerMinWorld">The first pixel to be saved.</param>
+        /// <param name="cornerMaxWorld">The last pixel to be saved.</param>
+        /// <param name="subCubeFitsPtr">The file pointer of the subcube, used to retrieve header information from.</param>
+        /// <param name="maskDataSet">The mask dataset from which to extract the data to be saved.</param>
+        /// <returns>0 if successful, a FITS error otherwise.</returns>
+        public int SaveSubMask(string filePath, Vector3Int cornerMinWorld, Vector3Int cornerMaxWorld, IntPtr subCubeFitsPtr, VolumeDataSet maskDataSet)
         {
             IntPtr subMaskFilePtr = IntPtr.Zero;
             IntPtr subCubeData = IntPtr.Zero;
             int status = 0;
+            Vector3Int regionVector = cornerMaxWorld - cornerMinWorld + Vector3Int.one;
+            int regionVolume = regionVector.x * regionVector.y * regionVector.z;
+            
             if (FitsReader.FitsCreateFile(out subMaskFilePtr, filePath, out status) == 0)
             {
                 if (FitsReader.FitsCopyHeader(subCubeFitsPtr, subMaskFilePtr, out status) == 0)
                 {
-                    if (DataAnalysis.MaskCropAndDownsample(maskDataSet.FitsData, out subCubeData, maskDataSet.XDim, maskDataSet.YDim, maskDataSet.ZDim, cornerMin.x, cornerMin.y, cornerMin.z, cornerMax.x, cornerMax.y, cornerMax.z, 1, 1, 1) == 0)
+                    if (DataAnalysis.MaskCropAndDownsample(maskDataSet.FitsData, out subCubeData, maskDataSet.XDim, maskDataSet.YDim, maskDataSet.ZDim, cornerMinWorld.x, cornerMinWorld.y, cornerMinWorld.z, cornerMaxWorld.x, cornerMaxWorld.y, cornerMaxWorld.z, 1, 1, 1) == 0)
                     {
-                        Vector3Int regionVector = cornerMax - cornerMin;
-                        int regionVolume = regionVector.x * regionVector.y * regionVector.z;
                         IntPtr keyValue = Marshal.AllocHGlobal(sizeof(int));
                         Marshal.WriteInt32(keyValue, 16);
                         if (FitsReader.FitsUpdateKey(subMaskFilePtr, 21, "BITPIX", keyValue, null, out status) == 0)
@@ -1504,20 +1519,36 @@ namespace VolumeData
                                 }
                             }
                             
-                            if (naxis != IntPtr.Zero)
-                                {
-                                    Marshal.FreeHGlobal(naxis);
-                                    naxis = IntPtr.Zero;
-                                }
                             if (FitsReader.FitsDeleteKey(subMaskFilePtr, "BUNIT", out status) != 0)
                             {
                                 Debug.Log("Could not delete unit key. It probably does not exist!");
                                 status = 0;
                             }
-                            FitsReader.FitsWriteImageInt16(subMaskFilePtr, 3, regionVolume, subCubeData, out status);
+                            //fptr, fPix, lPix, array, out
+                            int[] startPix = new int[Marshal.ReadInt32(naxis)];
+                            int[] finalPix = new int[Marshal.ReadInt32(naxis)];
+                            startPix[0] = 1;
+                            startPix[1] = 1;
+                            startPix[2] = 1;
+                            finalPix[0] = regionVector.x;
+                            finalPix[1] = regionVector.y;
+                            finalPix[2] = regionVector.z;
+
+                            IntPtr startPixPtr = Marshal.AllocHGlobal(sizeof(int) * startPix.Length);
+                            IntPtr finalPixPtr = Marshal.AllocHGlobal(sizeof(int) * finalPix.Length);
+                            Marshal.Copy(startPix, 0, startPixPtr, startPix.Length);
+                            Marshal.Copy(finalPix, 0, finalPixPtr, finalPix.Length);
+                            FitsReader.FitsWriteSubImageInt16(subMaskFilePtr, startPixPtr, finalPixPtr, subCubeData, out status);
                             if (status != 0)
                             {
                                 Debug.LogError($"Fits save mask cube data error #{status.ToString()}");
+                                ToastNotification.ShowError($"Fits save mask cube data error #{status.ToString()}");
+                            }
+                            
+                            if (naxis != IntPtr.Zero)
+                            {
+                                Marshal.FreeHGlobal(naxis);
+                                naxis = IntPtr.Zero;
                             }
                         }
                         if (keyValue != IntPtr.Zero)

--- a/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
@@ -1279,7 +1279,8 @@ namespace VolumeData
             long elements = (long) featureSize.x * (long) featureSize.y * (long) featureSize.z;
             if (elements > int.MaxValue)
             {
-                ToastNotification.ShowError($"Selected subcube too big for CFITSIO, select a smaller subcube with no more than {int.MaxValue} elements.");
+				long oversize = Mathf.RoundToInt((elements / int.MaxValue) * 100);
+                ToastNotification.ShowError($"Selected subcube ({featureSize.x} x {featureSize.y} x {featureSize.z}) {oversize}% too big for CFITSIO, select a smaller subcube with no more than {int.MaxValue} elements.");
                 return;
             }
             Debug.Log("Saving subcube from " + cornerMin.ToString() + " to " + cornerMax.ToString() + ".");

--- a/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
@@ -736,13 +736,22 @@ namespace VolumeData
         /// <summary>
         /// This function is used to get the cursor location in data space (i.e., including subcube offsets).
         /// </summary>
-        /// <param name="cursorPosWorldSpace">Where in the world space is the user pointing?</param>
         /// <returns>An indexed location in data space.</returns>
         public Vector3Int GetVoxelPositionDataSpace()
         {
             Vector3Int offset = new Vector3Int(_dataSet.subsetBounds[0], _dataSet.subsetBounds[2], _dataSet.subsetBounds[4]);
-
             return CursorVoxel + offset - new Vector3Int(1, 1, 1);
+        }
+
+        /// <summary>
+        /// This function is used to get a location in data space (i.e., including subcube offsets) that corresponds to a provided world space position.
+        /// </summary>
+        /// <param name="worldSpacePos">Where world space position needs to be converted?</param>
+        /// <returns>An indexed location in data space.</returns>
+        public Vector3Int GetVoxelPositionDataSpace(Vector3 worldSpacePos)
+        {
+            Vector3Int offset = new Vector3Int(_dataSet.subsetBounds[0], _dataSet.subsetBounds[2], _dataSet.subsetBounds[4]);
+            return Vector3Int.FloorToInt(worldSpacePos + offset - new Vector3Int(1, 1, 1));
         }
         
         /// <summary>
@@ -1251,20 +1260,30 @@ namespace VolumeData
         
         public void SaveSubCube()
         {
-            Vector3Int cornerMin, cornerMax;
+            Vector3Int cornerMin, cornerMax, cornerMinWorld, cornerMaxWorld, featureSize;
             if (_featureManager.SelectedFeature != null)
             {
-                cornerMin = Vector3Int.FloorToInt(_featureManager.SelectedFeature.CornerMin);
-                cornerMax = Vector3Int.FloorToInt(_featureManager.SelectedFeature.CornerMax);
+                cornerMinWorld = Vector3Int.FloorToInt(_featureManager.SelectedFeature.CornerMin);
+                cornerMaxWorld = Vector3Int.FloorToInt(_featureManager.SelectedFeature.CornerMax);
+                cornerMin = GetVoxelPositionDataSpace(cornerMinWorld);
+                cornerMax = GetVoxelPositionDataSpace(cornerMaxWorld);
             }
             else
             {
                 ToastNotification.ShowWarning("No feature selected, saving entire loaded cube as subcube.");
-                cornerMin = new Vector3Int(1, 1, 1);
-                cornerMax = GetCubeDimensions();
+                cornerMin = cornerMinWorld = new Vector3Int(1, 1, 1);
+                cornerMax = cornerMaxWorld = GetCubeDimensions();
+            }
+
+            featureSize = cornerMax - cornerMin + Vector3Int.one;
+            long elements = (long) featureSize.x * (long) featureSize.y * (long) featureSize.z;
+            if (elements > int.MaxValue)
+            {
+                ToastNotification.ShowError($"Selected subcube too big for CFITSIO, select a smaller subcube with no more than {int.MaxValue} elements.");
+                return;
             }
             Debug.Log("Saving subcube from " + cornerMin.ToString() + " to " + cornerMax.ToString() + ".");
-            _dataSet.SaveSubCubeFromOriginal(cornerMin, cornerMax, _maskDataSet);
+            _dataSet.SaveSubCubeFromOriginal(cornerMin, cornerMax, cornerMinWorld, cornerMaxWorld, _maskDataSet);
         }
 
         public void SaveMask(bool overwrite)

--- a/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
+++ b/Assets/Scripts/VolumeData/VolumeDataSetRenderer.cs
@@ -1280,7 +1280,7 @@ namespace VolumeData
             if (elements > int.MaxValue)
             {
 				long oversize = Mathf.RoundToInt((elements / int.MaxValue) * 100);
-                ToastNotification.ShowError($"Selected subcube ({featureSize.x} x {featureSize.y} x {featureSize.z}) {oversize}% too big for CFITSIO, select a smaller subcube with no more than {int.MaxValue} elements.");
+                ToastNotification.ShowError($"Selected subcube ({featureSize.x} x {featureSize.y} x {featureSize.z}) {oversize}% of maximum size supported by CFITSIO, select a smaller subcube with no more than {int.MaxValue} elements.");
                 return;
             }
             Debug.Log("Saving subcube from " + cornerMin.ToString() + " to " + cornerMax.ToString() + ".");

--- a/native_plugins_cmake/fits_reader.cpp
+++ b/native_plugins_cmake/fits_reader.cpp
@@ -54,6 +54,9 @@ int FitsOpenFileReadWrite(fitsfile** fptr, char* filename, int* status)
 
 int FitsCreateFile(fitsfile** fptr, char* filename, int* status)
 {
+    std::stringstream debug;
+    debug << "Creating file " << filename << ".";
+    WriteLogFile(defaultDebugFile.data(), debug.str().c_str(), 0);
     return fits_create_file(fptr, filename, status);
 }
 
@@ -172,6 +175,84 @@ int FitsCopyHeader(fitsfile *infptr, fitsfile *outfptr, int *status)
 int FitsCopyFile(fitsfile *infptr, fitsfile *outfptr, int *status)
 {
     int success = fits_copy_file(infptr, outfptr, 1, 1, 1, status);
+    return success;
+}
+
+int FitsCopyImageSection(char * inFile, char * outFile, char * section, char * historyTimeStamp, int selectedHDU, int * status)
+{
+    std::stringstream debug;
+    debug << "Copying image section " << section << " from " << inFile << " to " << outFile << ", targeting HDU #" << selectedHDU << ".";
+    WriteLogFile(defaultDebugFile.data(), debug.str().c_str(), 0);
+    fitsfile * infptr;
+    fitsfile * outfptr;
+    int success = FitsOpenFileReadOnly(&infptr, inFile, status);
+    if (success != 0)
+    {
+        debug.clear();
+        debug.str("");
+        debug << "Failed attempting to open fits file " << inFile << " with status code " << success << ".";
+        WriteLogFile(defaultDebugFile.data(), debug.str().c_str(), 0);
+        return success;
+    }
+
+    success = FitsCreateFile(&outfptr, outFile, status);
+    if (success != 0)
+    {
+        debug.clear();
+        debug.str("");
+        debug << "Failed attempting to create fits file " << outFile << " with status code " << success << ".";
+        WriteLogFile(defaultDebugFile.data(), debug.str().c_str(), 0);
+        FitsCloseFile(infptr, status);
+        FitsCloseFile(outfptr, status);
+        return success;
+    }
+
+    if (selectedHDU != 1)
+    {
+        success = FitsMovabsHdu(infptr, selectedHDU, nullptr, status);
+        if (success != 0)
+        {
+            debug.clear();
+            debug.str("");
+            debug << "Failed attempting to move to HDU " << selectedHDU << " in fits file " << inFile << " with status code " << success << ".";
+            WriteLogFile(defaultDebugFile.data(), debug.str().c_str(), 0);
+            FitsCloseFile(infptr, status);
+            FitsCloseFile(outfptr, status);
+            return success;
+        }
+    }
+    
+    success = FitsCopyCubeSection(infptr, outfptr, section, status);
+    if (success != 0)
+    {
+        debug.clear();
+        debug.str("");
+        debug << "Failed attempting to copy image section " << section << " from " << inFile << " to " << outFile << " with status code " << success << ".";
+        WriteLogFile(defaultDebugFile.data(), debug.str().c_str(), 0);
+        FitsCloseFile(infptr, status);
+        FitsCloseFile(outfptr, status);
+        return success;
+    }
+    debug.clear();
+    debug.str("");
+    debug << "Successfully copied image section " << section << " from " << inFile << " to " << outFile << " with status code " << success << ".";
+    WriteLogFile(defaultDebugFile.data(), debug.str().c_str(), 0);
+    
+    success = FitsWriteHistory(outfptr, historyTimeStamp, status);
+    if (success != 0)
+    {
+        debug.clear();
+        debug.str("");
+        debug << "Failed attempting to write history " << historyTimeStamp << " to " << outFile << " with status code " << success << ".";
+        WriteLogFile(defaultDebugFile.data(), debug.str().c_str(), 0);
+        FitsCloseFile(infptr, status);
+        FitsCloseFile(outfptr, status);
+        return success;
+    }
+
+    FitsFlushFile(outfptr, status);
+    FitsCloseFile(infptr, status);
+    FitsCloseFile(outfptr, status);
     return success;
 }
 

--- a/native_plugins_cmake/fits_reader.h
+++ b/native_plugins_cmake/fits_reader.h
@@ -89,6 +89,28 @@ DllExport int FitsCopyHeader(fitsfile *, fitsfile *, int *);
 
 DllExport int FitsCopyFile(fitsfile *, fitsfile *, int *);
 
+/**
+ * @brief Function writes a rectangular subset of the FITS image, which can be any size up to the full size of the image. This function is intended for use when saving a subcube.
+ * 
+ * @param oldFileName The fitsfile being worked on.
+ * @param filename The destination file name.
+ * @param section A char array containing the data bounds to be written to the file, in the form "Na1:Na2, Nb1:Nb2, ... Nx1:Nx2".
+ * @param historyTimeStamp A char array containing the history data to be written to the file header.
+ * @param selectedHDU The index of the active HDU.
+ * @param status Value containing outcome of CFITSIO operation.
+ * @return int The result code, 0 for success, a CFITSIO error coded if not.
+ */
+DllExport int FitsCopyImageSection(char * , char* , char* , char* , int , int* );
+
+/**
+ * @brief Function writes a rectangular subset of the FITS image, which can be any size up to the full size of the image. This function is intended for use when saving a subcube.
+ * 
+ * @param infptr The source file.
+ * @param outfptr The destination file.
+ * @param section A char array containing the data bounds to be written to the file, in the form "Na1:Na2, Nb1:Nb2, ... Nx1:Nx2".
+ * @param status Value containing outcome of CFITSIO operation.
+ * @return int The result code, 0 for success, a CFITSIO error coded if not.
+ */
 DllExport int FitsCopyCubeSection(fitsfile *, fitsfile *, char *, int *); 
 
 [[deprecated("Replaced by FitsWriteSubImageInt16, which is more flexible.")]]
@@ -114,6 +136,7 @@ DllExport int FitsWriteSubImageInt16(fitsfile * , long* , long* , int16_t* , int
  * @param fPix An array containing the indices of the first pixel (xyz, left bottom front) to be written.
  * @param lPix An array containing the indices of the last pixe (xyz, right top back) to be written.
  * @param array The array containing the data to be written. This is assumed to be at least the size of lPix - fPix.
+ * @param historyTimeStamp A char array containing the history data to be written to the file header.
  * @param status Value containing outcome of CFITSIO operation.
  * @return int The result code, 0 for success, a CFITSIO error code if not.
  */


### PR DESCRIPTION
Resolves #467.

### Changes:
 - Rewrite subcube saving to use `fits_copy_image_section()`.
 - Move all fits file handling for subcube saving to plugin.
 - Ensure that subcube saving only ever occurs in dataspace.
 - Mark `FitsWriteImageInt16()` as obsolete.
 - Pass worldspace coordinates through to `SaveSubMask()`.
 - Add error message if user tries to select a subcube bigger than 8 GB.